### PR TITLE
Implemented deleting experiences

### DIFF
--- a/client/src/features/experiences/components/ExperienceCard.tsx
+++ b/client/src/features/experiences/components/ExperienceCard.tsx
@@ -5,6 +5,7 @@ import Link from "@/features/shared/components/ui/Link";
 import { Button } from "@/features/shared/components/ui/Button";
 import { UserAvatar } from "@/features/users/components/UserAvatar";
 import { useCurrentUser } from "@/features/auth/hooks/useCurrentUser";
+import { ExperienceDeleteDialog } from "./ExperienceDeleteDialog";
 
 type ExperienceCardProps = {
   experience: ExperienceForList;
@@ -166,6 +167,8 @@ function ExperienceCardOwnerButtons({
           Edit
         </Link>
       </Button>
+
+      <ExperienceDeleteDialog experience={experience} />
     </div>
   );
 }

--- a/client/src/features/experiences/components/ExperienceDeleteDialog.tsx
+++ b/client/src/features/experiences/components/ExperienceDeleteDialog.tsx
@@ -1,0 +1,64 @@
+import { Button } from "@/features/shared/components/ui/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/features/shared/components/ui/Dialog";
+
+import { Experience } from "@meetup-app/server/database/schema";
+import { useState } from "react";
+import { useExperienceMutations } from "../hooks/useExperienceMutations";
+
+type ExperienceDeleteDialogProps = {
+  experience: Experience;
+  onSuccess?: (id: Experience["id"]) => void;
+};
+
+export function ExperienceDeleteDialog({
+  experience,
+  onSuccess,
+}: ExperienceDeleteDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { deleteMutation } = useExperienceMutations({
+    delete: {
+      onSuccess: (id) => {
+        setIsOpen(false);
+        onSuccess?.(id);
+      },
+    },
+  });
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button variant="destructive-link">Delete</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Experience</DialogTitle>
+        </DialogHeader>
+        <p className="text-neutral-600 dark:text-neutral-400">
+          Are you sure you wanr to delete this experience? This action cannot be
+          undone.
+        </p>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setIsOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            type="submit"
+            onClick={() => deleteMutation.mutate({ id: experience.id })}
+            disabled={deleteMutation.isPending}
+          >
+            {deleteMutation.isPending ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/features/experiences/components/ExperienceDeleteDialog.tsx
+++ b/client/src/features/experiences/components/ExperienceDeleteDialog.tsx
@@ -42,7 +42,7 @@ export function ExperienceDeleteDialog({
           <DialogTitle>Delete Experience</DialogTitle>
         </DialogHeader>
         <p className="text-neutral-600 dark:text-neutral-400">
-          Are you sure you wanr to delete this experience? This action cannot be
+          Are you sure you want to delete this experience? This action cannot be
           undone.
         </p>
         <DialogFooter>

--- a/client/src/features/experiences/components/ExperienceDetails.tsx
+++ b/client/src/features/experiences/components/ExperienceDetails.tsx
@@ -4,6 +4,8 @@ import { ExperienceForDetails } from "../types";
 import { useCurrentUser } from "@/features/auth/hooks/useCurrentUser";
 import { Button } from "@/features/shared/components/ui/Button";
 import Link from "@/features/shared/components/ui/Link";
+import { ExperienceDeleteDialog } from "./ExperienceDeleteDialog";
+import { router } from "@/router";
 
 type ExperienceDetailsProps = {
   experience: ExperienceForDetails;
@@ -127,6 +129,13 @@ function ExperienceCardOwnerButtons({
           Edit
         </Link>
       </Button>
+
+      <ExperienceDeleteDialog
+        experience={experience}
+        onSuccess={() => {
+          router.navigate({ to: "/" });
+        }}
+      />
     </div>
   );
 }

--- a/client/src/features/experiences/hooks/useExperienceMutations.ts
+++ b/client/src/features/experiences/hooks/useExperienceMutations.ts
@@ -1,9 +1,13 @@
 import { useToast } from "@/features/shared/hooks/useToast";
 import { trpc } from "@/router";
 import { Experience } from "@meetup-app/server/database/schema";
+import { useParams, useSearch } from "@tanstack/react-router";
 
 type ExperienceMutationOptions = {
   edit?: {
+    onSuccess?: (id: Experience["id"]) => void;
+  };
+  delete?: {
     onSuccess?: (id: Experience["id"]) => void;
   };
 };
@@ -13,6 +17,10 @@ export function useExperienceMutations(
 ) {
   const { toast } = useToast();
   const utils = trpc.useUtils();
+
+  const { userId: pathUserId } = useParams({ strict: false });
+
+  const { q: pathQ } = useSearch({ strict: false });
 
   const editMutation = trpc.experiences.edit.useMutation({
     onSuccess: async ({ id }) => {
@@ -34,7 +42,34 @@ export function useExperienceMutations(
     },
   });
 
+  const deleteMutation = trpc.experiences.delete.useMutation({
+    onSuccess: async (id) => {
+      await Promise.all([
+        utils.experiences.feed.invalidate(),
+        ...(pathUserId
+          ? [utils.experiences.byUserId.invalidate({ id: pathUserId })]
+          : []),
+        ...(pathQ ? [utils.experiences.search.invalidate({ q: pathQ })] : []),
+      ]);
+
+      toast({
+        title: "Experience deleted",
+        description: "Your experience has been deleted",
+      });
+
+      options.delete?.onSuccess?.(id);
+    },
+    onError: (error) => {
+      toast({
+        title: "Failed to delete experience",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
   return {
     editMutation,
+    deleteMutation,
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability for experience owners to delete their experiences via a confirmation dialog.
  - Added a delete button alongside the edit option on experience cards and details pages.
  - Users are redirected to the homepage after successful deletion of an experience.
  - Toast notifications provide feedback for successful or failed deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->